### PR TITLE
Add example for precaching Cloudinary images (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ Here’s an example of setting configuration parameters in your Flutter applicat
 ```dart
 Cloudinary cloudinary = CloudinaryObject.fromCloudName(cloudName: 'demo');
 ```
+### Pre-caching Images
+Flutter allows you to pre-load Cloudinary images into memory so they display instantly when needed. This improves performance and provides a smoother user experience.
+
+Example:
+
+```dart
+// Precache a Cloudinary image in Flutter
+void precacheCloudinaryImage(BuildContext context) {
+  final image = CldImageWidget(
+    publidId: 'sample',
+    transformation: Transformation()
+      ..resize(Resize.scale()..width(500)),
+  );
+
+  // Preload the image into cache
+  precacheImage(image.imageProvider, context);
+}
+
 
 ### Transform and Optimize Assets
 


### PR DESCRIPTION
This PR adds a pre-caching example for Cloudinary images in Flutter, improving image load performance.

Closes #19

### Brief Summary of Changes
Added a new section in README.md for pre-caching Cloudinary images in Flutter to improve app performance and user experience.

#### What does this PR address?
- [x] GitHub issue (#19)
- [ ] Refactoring
- [x] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [ ] Yes
- [x] No

#### Reviewer, please note:
This PR only updates the documentation (README.md) to include a pre-caching example. No code logic is changed.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.

