### PR TITLE
Feature/remove usage of cloudinary context

### DIFF
--- a/lib/image/cld_image.dart
+++ b/lib/image/cld_image.dart
@@ -5,8 +5,6 @@ import 'package:cloudinary_url_gen/transformation/transformation.dart';
 import 'package:cloudinary_flutter/image/no_disk_cache_manager.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
-
-import '../cloudinary_context.dart';
 import 'cld_image_widget_configuration.dart';
 
 /// A widget that displays a Cloudinary-hosted image. Its constructor offers various attributes to customize image presentation.
@@ -20,7 +18,7 @@ class CldImageWidget extends CachedNetworkImage {
       {required String publicId,
       super.key,
       this.configuration,
-      Cloudinary? cloudinary,
+      required Cloudinary cloudinary,
       String? version,
       String? extension,
       String? urlSuffix,
@@ -65,7 +63,6 @@ class CldImageWidget extends CachedNetworkImage {
             fit: fit,
             repeat: repeat,
             matchTextDirection: matchTextDirection) {
-    cloudinary ??= CloudinaryContext.cloudinary;
     cldImage = cloudinary.image(publicId);
     if (version != null) {
       cldImage.version(version);

--- a/lib/video/cld_video_controller.dart
+++ b/lib/video/cld_video_controller.dart
@@ -4,7 +4,6 @@ import 'package:cloudinary_url_gen/transformation/transformation.dart';
 import 'package:cloudinary_url_gen/transformation/video_edit/transcode/transcode.dart';
 import 'package:cloudinary_url_gen/transformation/video_edit/transcode/transcode_actions.dart';
 import 'package:video_player/video_player.dart';
-import '../cloudinary_context.dart';
 import 'analytics/video_analytics.dart';
 import 'analytics/video_events_manager.dart';
 
@@ -12,6 +11,7 @@ import 'dart:ui';
 
 class CldVideoController extends VideoPlayerController
     with VideoControllerListeners {
+  @override
   late final Uri uri;
   @override
   late VideoEventsManager eventsManager;
@@ -43,7 +43,7 @@ class CldVideoController extends VideoPlayerController
 
   CldVideoController({
     required String publicId,
-    Cloudinary? cloudinary,
+    required Cloudinary cloudinary,
     String? version,
     String? extension,
     String? urlSuffix,
@@ -62,13 +62,13 @@ class CldVideoController extends VideoPlayerController
             transformation,
             automaticStreamingProfile)) {
     eventsManager = VideoEventsManager(
-        cloudName: cloudinary?.config.cloudConfig.cloudName,
+        cloudName: cloudinary.config.cloudConfig.cloudName,
         publicId: publicId);
   }
 
   static Uri _buildVideoUri(
     String publicId,
-    Cloudinary? cloudinary,
+    Cloudinary cloudinary,
     String? version,
     String? extension,
     String? urlSuffix,
@@ -77,7 +77,6 @@ class CldVideoController extends VideoPlayerController
     Transformation? transformation,
     bool? automaticStreamingProfile,
   ) {
-    cloudinary ??= CloudinaryContext.cloudinary;
     CldVideo video = cloudinary.video(publicId);
     ((version != null) ? video.version(version) : null);
     ((extension != null) ? video.extension(extension) : null);

--- a/test/cld_video_controller_test.dart
+++ b/test/cld_video_controller_test.dart
@@ -1,4 +1,3 @@
-import 'package:cloudinary_flutter/cloudinary_context.dart';
 import 'package:cloudinary_flutter/cloudinary_object.dart';
 import 'package:cloudinary_flutter/video/analytics/video_analytics.dart';
 import 'package:cloudinary_flutter/video/cld_video_controller.dart';
@@ -10,9 +9,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   SharedPreferences.setMockInitialValues({'user_id': '12345'});
-  CloudinaryContext.cloudinary =
-      Cloudinary.fromCloudName(cloudName: 'test_cloud');
-  CloudinaryContext.cloudinary.config.urlConfig.analytics = false;
+  Cloudinary cloudinary = CloudinaryObject.fromCloudName(cloudName: 'test_cloud');
+  cloudinary.config.urlConfig.analytics = false;
   group('CldVideoController Tests', () {
     test('CldVideoController.networkUrl() sets correct URI', () {
       final Uri testUri = Uri.parse('https://example.com/video.mp4');
@@ -36,6 +34,7 @@ void main() {
 
       final CldVideoController controller = CldVideoController(
         publicId: publicId,
+        cloudinary: cloudinary,
         version: version,
         extension: extension,
         assetType: assetType,
@@ -56,6 +55,7 @@ void main() {
 
       final CldVideoController controller = CldVideoController(
         publicId: publicId,
+        cloudinary: cloudinary,
         automaticStreamingProfile: true,
       );
 
@@ -74,6 +74,7 @@ void main() {
 
       final CldVideoController controller = CldVideoController(
         publicId: publicId,
+        cloudinary: cloudinary,
         transformation: transformation,
       );
 


### PR DESCRIPTION
### Brief Summary of Changes
This pull request refactors both the image and video components to require an explicit `Cloudinary` instance, removing implicit dependency on the global `CloudinaryContext`. This change improves code clarity and testability by making dependencies explicit. The test code is also updated to reflect these changes.

**Dependency Injection Refactor**

* The constructors for both `CldImageWidget` (`lib/image/cld_image.dart`) and `CldVideoController` (`lib/video/cld_video_controller.dart`) now require a `Cloudinary` instance to be passed explicitly, instead of optionally falling back to a global singleton.
* All internal usages of `cloudinary` in these classes now assume it is non-null and directly reference its properties, removing fallback logic and null checks.

**Test Updates**

* The test file `test/cld_video_controller_test.dart` is updated to create and configure a local `Cloudinary` instance instead of using the global `CloudinaryContext`, and all test usages of `CldVideoController` are updated to pass this instance explicitly.

**Cleanup**

* Unused imports of `cloudinary_context.dart` are removed from both the image and video Dart files, as well as from the test file. 

#### What does this PR address?
- [X] GitHub issue (Add reference - #41)
- [X] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [X] Yes
- [ ] No

#### Reviewer, please note:
**Since we don't want to rely on CloudinaryContext internally anymore, as it is deprecated, I made the Cloudinary argument required.**

#### Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I ran the full test suite before pushing the changes and all the tests pass.

![tests](https://github.com/user-attachments/assets/d7cdfd93-3d04-4d59-8993-7038c04e0064)
